### PR TITLE
Major Helper Classes Update

### DIFF
--- a/src/Enums.java
+++ b/src/Enums.java
@@ -37,3 +37,10 @@ enum ImageID {
     MenuScene,
     SoundIcons
 }
+
+/// Handles font sized
+enum FontID {
+    Silk30,
+    Silk40,
+    Silk60
+}

--- a/src/GameOverScene.java
+++ b/src/GameOverScene.java
@@ -51,7 +51,7 @@ class GameOverScene extends SirtetScene implements ActionListener {
         nameField.requestFocusInWindow();
     }
 
-    void addScene(JFrame parentFrame) {
+    void addScene() {
         setVisible(true);
         scoreLabel = new LabelCenter("Score: " + SaveData.currentScore, FontID.Silk40, 475);
         add(scoreLabel);
@@ -59,7 +59,7 @@ class GameOverScene extends SirtetScene implements ActionListener {
         focusField();
     }
 
-    void removeScene(JFrame parentFrame) {
+    void removeScene() {
         remove(scoreLabel);
         setVisible(false);
     }

--- a/src/GameOverScene.java
+++ b/src/GameOverScene.java
@@ -8,14 +8,13 @@ import java.awt.event.ActionListener;
  * and then sends it off to SaveData.java to be inserted or thrown away, depending on whether it makes it
  * into the top 10 scores list. The user will be told if their name is over 10 characters or under 3, as these names
  * will not be allowed. After receiving a name, it inserts the score, and switches to the high score scene. */
-class GameOverScene extends SirtetPanel implements ActionListener {
+class GameOverScene extends SirtetScene implements ActionListener {
     private JTextField nameField = nameField();
 
     public GameOverScene() {
         super(true);
-
-        add(SirtetWindow.labelCenter("<html><p style=\"text-align:center;\">Game Over!<br>Enter Your Name:</p>", Sirtet.SILKSCREEN_40, 275));
-        add(SirtetWindow.labelCenter("Score: " + SaveData.currentScore, Sirtet.SILKSCREEN_40, 475));
+        add(new LabelCenter("<html><p style=\"text-align:center;\">Game Over!<br>Enter Your Name:</p>", FontID.Silk40, 275));
+        add(new LabelCenter("Score: " + SaveData.currentScore, FontID.Silk40, 475));
         add(nameField);
     }
 
@@ -25,11 +24,10 @@ class GameOverScene extends SirtetPanel implements ActionListener {
         field.setOpaque(false);
         field.setBounds(150, 400, 300, 50);
         field.setForeground(Color.black);
-        field.setFont(Sirtet.SILKSCREEN_30);
+        field.setFont(SirtetWindow.getFont(FontID.Silk30));
         field.addActionListener(this);
         field.setHorizontalAlignment(JTextField.CENTER);
         field.setBorder(null);
-
         return field;
     }
 
@@ -51,5 +49,15 @@ class GameOverScene extends SirtetPanel implements ActionListener {
     ///  Called when field needs to become focused to accept user-input
     public void focusField() {
         nameField.requestFocusInWindow();
+    }
+
+    void addScene(JFrame parentFrame) {
+        setVisible(true);
+        nameField.setText("");
+        focusField();
+    }
+
+    void removeScene(JFrame parentFrame) {
+        setVisible(false);
     }
 }

--- a/src/GameOverScene.java
+++ b/src/GameOverScene.java
@@ -10,11 +10,11 @@ import java.awt.event.ActionListener;
  * will not be allowed. After receiving a name, it inserts the score, and switches to the high score scene. */
 class GameOverScene extends SirtetScene implements ActionListener {
     private JTextField nameField = nameField();
+    private JLabel scoreLabel;
 
     public GameOverScene() {
         super(true);
         add(new LabelCenter("<html><p style=\"text-align:center;\">Game Over!<br>Enter Your Name:</p>", FontID.Silk40, 275));
-        add(new LabelCenter("Score: " + SaveData.currentScore, FontID.Silk40, 475));
         add(nameField);
     }
 
@@ -53,11 +53,14 @@ class GameOverScene extends SirtetScene implements ActionListener {
 
     void addScene(JFrame parentFrame) {
         setVisible(true);
+        scoreLabel = new LabelCenter("Score: " + SaveData.currentScore, FontID.Silk40, 475);
+        add(scoreLabel);
         nameField.setText("");
         focusField();
     }
 
     void removeScene(JFrame parentFrame) {
+        remove(scoreLabel);
         setVisible(false);
     }
 }

--- a/src/GameplayScene.java
+++ b/src/GameplayScene.java
@@ -7,22 +7,16 @@ import java.util.ConcurrentModificationException;
 /**
  * This class handles the main gameplay scene, and all within. It also needs a SirtetGrid object to pass user
  * input to. */
-class GameplayScene extends SirtetPanel implements KeyListener {
-    private JLabel score = SirtetWindow.labelLeft("", Sirtet.SILKSCREEN_60, 0, 0);
-
+class GameplayScene extends SirtetScene implements KeyListener {
+    private JLabel score = new LabelCenter("", FontID.Silk60, 0);
     private JPanel pausePanel = pausePanelSetup();
     private JPanel playPanel = playPanelSetup();
-
     private boolean isPaused = false;
-
-    private SirtetGrid grid = new SirtetGrid(this);
+    private SirtetGrid grid;
 
     public GameplayScene() {
         super(true);
-        
-        SaveData.currentScore = 0;
         updateScoreLabel();
-
         add(playPanel);
         add(pausePanel);
     }
@@ -34,9 +28,7 @@ class GameplayScene extends SirtetPanel implements KeyListener {
             drawHeld(g);
             g.drawImage(Sirtet.gameplaySceneImages[7], 0, 0, Sirtet.observer);
         });
-
         panel.add(score);
-        
         return panel;
     }
 
@@ -44,7 +36,6 @@ class GameplayScene extends SirtetPanel implements KeyListener {
     public void drawPremonition(Graphics g) {
         g.setColor(new Color(87, 223, 255));
         int height = grid.getLastSonimortet().getHeight();
-        
         for (SonimortetPositions pos : grid.getLastPositions())
             g.fillRect(173 + 38 * pos.getX(), 132 + 38 * (pos.getY() + height), 36, 36);
     }
@@ -58,8 +49,9 @@ class GameplayScene extends SirtetPanel implements KeyListener {
                 for (SonimortetPositions currentPosition : currentSonimortet.getPositions())
                     g.drawImage(currentImage, 173 + 38 * currentPosition.getX(), 132 + 38 * currentPosition.getY(), Sirtet.observer);
             }
+        }
         /// Will keep recursively calling itself if the list is being modified until the list is ready
-        } catch (ConcurrentModificationException ignored) {
+        catch (ConcurrentModificationException ignored) {
             drawReal(g);
         }
     }
@@ -81,13 +73,10 @@ class GameplayScene extends SirtetPanel implements KeyListener {
     /// Sets up and returns the pause panel
     public SirtetPanel pausePanelSetup() {
         SirtetPanel panel = new SirtetPanel(false);
-        
-        panel.add(new ReactiveButton(Sirtet.menuImages[3], 400, e -> SirtetWindow.changeScene(SceneID.Menu)));
-        panel.add(SirtetWindow.labelCenter("Game Paused", Sirtet.SILKSCREEN_60, 250));
+        panel.add(new SirtetButton(Sirtet.menuImages[3], 400, e -> SirtetWindow.changeScene(SceneID.Menu)));
+        panel.add(new LabelCenter("Game Paused", FontID.Silk60, 250));
         panel.add(new VolumeSliders());
-
         panel.setVisible(false);
-        
         return panel;
     }
 
@@ -170,12 +159,23 @@ class GameplayScene extends SirtetPanel implements KeyListener {
             grid.swapHeld();
         }
 
-        grid.updateGrid(true);
+        if (grid != null)
+            grid.updateGrid(true);
     }
 
-    /// Returns the SirtetGrid class object in use by this class
-    public SirtetGrid getGrid() {
-        return grid;
+    public void addScene(JFrame parentFrame) {
+        SaveData.currentScore = 0;
+        grid = new SirtetGrid(this);
+        parentFrame.addKeyListener(this);
+        parentFrame.getContentPane().add(this);
+        setVisible(true);
+    }
+
+    public void removeScene(JFrame parentFrame) {
+        grid = null;
+        parentFrame.removeKeyListener(this);
+        parentFrame.getContentPane().remove(this);
+        setVisible(false);
     }
 
     public void keyTyped(KeyEvent e) {}

--- a/src/GameplayScene.java
+++ b/src/GameplayScene.java
@@ -11,7 +11,7 @@ class GameplayScene extends SirtetScene implements KeyListener {
     private JLabel score = new LabelCenter("", FontID.Silk60, 0);
     private JPanel pausePanel = pausePanelSetup();
     private JPanel playPanel = playPanelSetup();
-    private boolean isPaused = false;
+    private boolean isPaused;
     private SirtetGrid grid;
 
     public GameplayScene() {
@@ -164,8 +164,11 @@ class GameplayScene extends SirtetScene implements KeyListener {
     }
 
     public void addScene(JFrame parentFrame) {
-        SaveData.currentScore = 0;
         grid = new SirtetGrid(this);
+        SaveData.currentScore = 0;
+        if (isPaused)
+            invertPause();
+        updateScoreLabel();
         parentFrame.addKeyListener(this);
         parentFrame.getContentPane().add(this);
         setVisible(true);

--- a/src/GameplayScene.java
+++ b/src/GameplayScene.java
@@ -50,7 +50,7 @@ class GameplayScene extends SirtetScene implements KeyListener {
                     g.drawImage(currentImage, 173 + 38 * currentPosition.getX(), 132 + 38 * currentPosition.getY(), Sirtet.observer);
             }
         }
-        /// Will keep recursively calling itself if the list is being modified until the list is ready
+        // Will keep recursively calling itself if the list is being modified until the list is ready
         catch (ConcurrentModificationException ignored) {
             drawReal(g);
         }
@@ -73,7 +73,7 @@ class GameplayScene extends SirtetScene implements KeyListener {
     /// Sets up and returns the pause panel
     public SirtetPanel pausePanelSetup() {
         SirtetPanel panel = new SirtetPanel(false);
-        panel.add(new SirtetButton(Sirtet.menuImages[3], 400, e -> SirtetWindow.changeScene(SceneID.Menu)));
+        panel.add(new SirtetButton(Sirtet.menuImages[3], 400, () -> SirtetWindow.changeScene(SceneID.Menu)));
         panel.add(new LabelCenter("Game Paused", FontID.Silk60, 250));
         panel.add(new VolumeSliders());
         panel.setVisible(false);

--- a/src/GameplayScene.java
+++ b/src/GameplayScene.java
@@ -163,21 +163,21 @@ class GameplayScene extends SirtetScene implements KeyListener {
             grid.updateGrid(true);
     }
 
-    public void addScene(JFrame parentFrame) {
+    public void addScene() {
         grid = new SirtetGrid(this);
         SaveData.currentScore = 0;
         if (isPaused)
             invertPause();
         updateScoreLabel();
-        parentFrame.addKeyListener(this);
-        parentFrame.getContentPane().add(this);
+        SirtetWindow.frame.addKeyListener(this);
+        SirtetWindow.frame.getContentPane().add(this);
         setVisible(true);
     }
 
-    public void removeScene(JFrame parentFrame) {
+    public void removeScene() {
         grid = null;
-        parentFrame.removeKeyListener(this);
-        parentFrame.getContentPane().remove(this);
+        SirtetWindow.frame.removeKeyListener(this);
+        SirtetWindow.frame.getContentPane().remove(this);
         setVisible(false);
     }
 

--- a/src/HighScore.java
+++ b/src/HighScore.java
@@ -1,6 +1,6 @@
 /**
- * Data class containing individual high scores and their associated names, along with getter/setter
- * methods and toString override. toString override is in the format used by SaveData class. */
+ * Data class containing individual high scores and their associated names, along with getter
+ * methods and toString override. The toString override is in the format used by SaveData class. */
 class HighScore {
     private String name;
     private int score;

--- a/src/HighScoreScene.java
+++ b/src/HighScoreScene.java
@@ -27,27 +27,30 @@ class HighScoreScene extends SirtetScene implements KeyListener {
     /// Sets up label arrays for use in the scene
     public void loadLabels() {
         for (int i = 0; i < 10; i++) {
-            HighScore currentHS = SaveData.highScores[i];
-
             indexLabels[i] = new LabelRight(i + 1 + ": ", FontID.Silk30, 110, 160 + i * 50);
-            nameLabels[i] = new LabelRight(currentHS.getName(), FontID.Silk30, 360, 160 + i * 50);
-            scoreLabels[i] = new LabelRight("" + currentHS.getScore(), FontID.Silk30, 550, 160 + i * 50);
+            nameLabels[i] = new LabelRight("", FontID.Silk30, 0, 0);
+            scoreLabels[i] = new LabelRight("", FontID.Silk30, 0, 0);
         }
     }
 
-    public void reloadLabel(JLabel label, String text, int xPos, int yPos) {
-        label.setText(text);
-        final int preferredWidth = label.getPreferredSize().width;
-        final int preferredHeight = label.getPreferredSize().height;
-        label.setBounds(xPos - preferredWidth, yPos, preferredWidth, preferredHeight);
+    /// Updates labels to reflect changes with the help of method "reloadLabel()"
+    public void reloadAllLabels() {
+        for (int i = 0; i < 10; i++) {
+            scoreLabels[i].setText("" + SaveData.highScores[i].getScore());
+            int width = scoreLabels[i].getPreferredSize().width;
+            int height = scoreLabels[i].getPreferredSize().height;
+            scoreLabels[i].setBounds(550 - width, 160 + i * 50, width, height);
+
+            nameLabels[i].setText(SaveData.highScores[i].getName());
+            width = nameLabels[i].getPreferredSize().width;
+            height = nameLabels[i].getPreferredSize().height;
+            nameLabels[i].setBounds(360 - width, 160 + i * 50, width, height);
+        }
     }
 
     void addScene(JFrame parentFrame) {
         parentFrame.addKeyListener(this);
-        for (int i = 0; i < 10; i++) {
-            reloadLabel(scoreLabels[i], "" + SaveData.highScores[i].getScore(), 550, 160 + i * 50);
-            reloadLabel(nameLabels[i], SaveData.highScores[i].getName(), 360, 160 + i * 50);
-        }
+        reloadAllLabels();
         setVisible(true);
     }
 

--- a/src/HighScoreScene.java
+++ b/src/HighScoreScene.java
@@ -6,17 +6,15 @@ import java.awt.event.KeyListener;
  * This class holds the JPanel and everything within needed for the high score menu to be made visible and
  * populated with the necessary data. It uses 3 JLabel arrays, each with a part of the data gathered by
  * SaveData.java. A given name label will have the same index as the score label associated with it. */
-class HighScoreScene extends SirtetPanel implements KeyListener {
+class HighScoreScene extends SirtetScene implements KeyListener {
     private JLabel[] indexLabels = new JLabel[10];
     private JLabel[] nameLabels = new JLabel[10];
     private JLabel[] scoreLabels = new JLabel[10];
 
     public HighScoreScene() {
         super(true);
-
-        add(SirtetWindow.labelCenter("Highscores", Sirtet.SILKSCREEN_60, 50));
-        add(SirtetWindow.labelCenter("ESC to Return", Sirtet.SILKSCREEN_30, 725));
-
+        add(new LabelCenter("Highscores", FontID.Silk60, 50));
+        add(new LabelCenter("ESC to Return", FontID.Silk30, 725));
         loadLabels();
 
         for (int i = 0; i < 10; i++) {
@@ -31,9 +29,18 @@ class HighScoreScene extends SirtetPanel implements KeyListener {
         for (int i = 0; i < 10; i++) {
             HighScore currentHS = SaveData.highScores[i];
 
-            indexLabels[i] = SirtetWindow.labelRight(i + 1 + ": ", Sirtet.SILKSCREEN_30, 110, 160 + i * 50);
-            nameLabels[i] = SirtetWindow.labelRight(currentHS.getName(), Sirtet.SILKSCREEN_30, 360, 160 + i * 50);
-            scoreLabels[i] = SirtetWindow.labelRight("" + currentHS.getScore(), Sirtet.SILKSCREEN_30, 550, 160 + i * 50);
+            indexLabels[i] = new LabelRight(i + 1 + ": ", FontID.Silk30, 110, 160 + i * 50);
+            nameLabels[i] = new LabelRight(currentHS.getName(), FontID.Silk30, 360, 160 + i * 50);
+            scoreLabels[i] = new LabelRight("" + currentHS.getScore(), FontID.Silk30, 550, 160 + i * 50);
+        }
+    }
+
+    public void reloadLabels() {
+        for (int i = 0; i < 10; i++) {
+            HighScore currentHS = SaveData.highScores[i];
+
+            nameLabels[i] = new LabelRight(currentHS.getName(), FontID.Silk30, 360, 160 + i * 50);
+            scoreLabels[i] = new LabelRight("" + currentHS.getScore(), FontID.Silk30, 550, 160 + i * 50);
         }
     }
 
@@ -41,6 +48,18 @@ class HighScoreScene extends SirtetPanel implements KeyListener {
     public void keyPressed(KeyEvent e) {
         if (e.getKeyCode() == KeyEvent.VK_ESCAPE)
             SirtetWindow.changeScene(SceneID.Menu);
+    }
+
+    void addScene(JFrame parentFrame) {
+        System.out.println("Highscore reloaded");
+        parentFrame.addKeyListener(this);
+        reloadLabels();
+        setVisible(true);
+    }
+
+    void removeScene(JFrame parentFrame) {
+        parentFrame.removeKeyListener(this);
+        setVisible(false);
     }
 
     public void keyTyped(KeyEvent e) {}

--- a/src/HighScoreScene.java
+++ b/src/HighScoreScene.java
@@ -35,15 +35,6 @@ class HighScoreScene extends SirtetScene implements KeyListener {
         }
     }
 
-    public void reloadLabels() {
-        for (int i = 0; i < 10; i++) {
-            HighScore currentHS = SaveData.highScores[i];
-
-            nameLabels[i] = new LabelRight(currentHS.getName(), FontID.Silk30, 360, 160 + i * 50);
-            scoreLabels[i] = new LabelRight("" + currentHS.getScore(), FontID.Silk30, 550, 160 + i * 50);
-        }
-    }
-
     /// When escape is pressed go to main menu, else do nothing
     public void keyPressed(KeyEvent e) {
         if (e.getKeyCode() == KeyEvent.VK_ESCAPE)
@@ -51,9 +42,7 @@ class HighScoreScene extends SirtetScene implements KeyListener {
     }
 
     void addScene(JFrame parentFrame) {
-        System.out.println("Highscore reloaded");
         parentFrame.addKeyListener(this);
-        reloadLabels();
         setVisible(true);
     }
 

--- a/src/HighScoreScene.java
+++ b/src/HighScoreScene.java
@@ -48,14 +48,14 @@ class HighScoreScene extends SirtetScene implements KeyListener {
         }
     }
 
-    void addScene(JFrame parentFrame) {
-        parentFrame.addKeyListener(this);
+    void addScene() {
+        SirtetWindow.frame.addKeyListener(this);
         reloadAllLabels();
         setVisible(true);
     }
 
-    void removeScene(JFrame parentFrame) {
-        parentFrame.removeKeyListener(this);
+    void removeScene() {
+        SirtetWindow.frame.removeKeyListener(this);
         setVisible(false);
     }
 

--- a/src/HighScoreScene.java
+++ b/src/HighScoreScene.java
@@ -41,8 +41,19 @@ class HighScoreScene extends SirtetScene implements KeyListener {
             SirtetWindow.changeScene(SceneID.Menu);
     }
 
+    public void reloadLabel(JLabel label, String text, int xPos, int yPos) {
+        label.setText(text);
+        final int preferredWidth = label.getPreferredSize().width;
+        final int preferredHeight = label.getPreferredSize().height;
+        label.setBounds(xPos - preferredWidth, yPos, preferredWidth, preferredHeight);
+    }
+
     void addScene(JFrame parentFrame) {
         parentFrame.addKeyListener(this);
+        for (int i = 0; i < 10; i++) {
+            reloadLabel(scoreLabels[i], "" + SaveData.highScores[i].getScore(), 550, 160 + i * 50);
+            reloadLabel(nameLabels[i], SaveData.highScores[i].getName(), 360, 160 + i * 50);
+        }
         setVisible(true);
     }
 

--- a/src/HighScoreScene.java
+++ b/src/HighScoreScene.java
@@ -35,12 +35,6 @@ class HighScoreScene extends SirtetScene implements KeyListener {
         }
     }
 
-    /// When escape is pressed go to main menu, else do nothing
-    public void keyPressed(KeyEvent e) {
-        if (e.getKeyCode() == KeyEvent.VK_ESCAPE)
-            SirtetWindow.changeScene(SceneID.Menu);
-    }
-
     public void reloadLabel(JLabel label, String text, int xPos, int yPos) {
         label.setText(text);
         final int preferredWidth = label.getPreferredSize().width;
@@ -60,6 +54,12 @@ class HighScoreScene extends SirtetScene implements KeyListener {
     void removeScene(JFrame parentFrame) {
         parentFrame.removeKeyListener(this);
         setVisible(false);
+    }
+
+    /// When escape is pressed go to main menu, else do nothing
+    public void keyPressed(KeyEvent e) {
+        if (e.getKeyCode() == KeyEvent.VK_ESCAPE)
+            SirtetWindow.changeScene(SceneID.Menu);
     }
 
     public void keyTyped(KeyEvent e) {}

--- a/src/HighScoreScene.java
+++ b/src/HighScoreScene.java
@@ -65,6 +65,6 @@ class HighScoreScene extends SirtetScene implements KeyListener {
             SirtetWindow.changeScene(SceneID.Menu);
     }
 
-    public void keyTyped(KeyEvent e) {}
-    public void keyReleased(KeyEvent e) {}
+    public void keyTyped(KeyEvent ignored) {}
+    public void keyReleased(KeyEvent ignored) {}
 }

--- a/src/MenuScene.java
+++ b/src/MenuScene.java
@@ -1,16 +1,23 @@
+import javax.swing.*;
+
 /**
  * This class handles the menu scene and panel. It can launch a new GameplayScene instance, HighScoreScene instance,
  * quit to desktop, or change the bgm/sfx volumes. The JSliders communicate to SirtetAudio to change volume. */
-class MenuScene extends SirtetPanel {
+class MenuScene extends SirtetScene {
     public MenuScene() {
         super(false);
-
-        add(new ReactiveButton(Sirtet.menuImages[0], 260, e -> SirtetWindow.changeScene(SceneID.Gameplay)));
-        add(new ReactiveButton(Sirtet.menuImages[1], 320, e -> SirtetWindow.changeScene(SceneID.HighScore)));
-        add(new ReactiveButton(Sirtet.menuImages[2], 380, e -> {SaveData.writeFile(); System.exit(0);}));
-
         add(new VolumeSliders());
+        add(new SirtetButton(Sirtet.menuImages[ImageID.PlayButton.ordinal()], 260, e -> SirtetWindow.changeScene(SceneID.Gameplay)));
+        add(new SirtetButton(Sirtet.menuImages[ImageID.HighScoreButton.ordinal()], 320, e -> SirtetWindow.changeScene(SceneID.HighScore)));
+        add(new SirtetButton(Sirtet.menuImages[ImageID.QuitButton.ordinal()], 380, e -> {SaveData.writeFile();System.exit(0);}));
+        add(new SirtetPanel(false, g -> g.drawImage(Sirtet.menuImages[ImageID.MenuScene.ordinal()], 0, 0, Sirtet.observer)));
+    }
 
-        add(new SirtetPanel(false, g -> g.drawImage(Sirtet.menuImages[4], 0, 0, Sirtet.observer)));
+    void addScene(JFrame parentFrame) {
+        setVisible(true);
+    }
+
+    void removeScene(JFrame parentFrame) {
+        setVisible(false);
     }
 }

--- a/src/MenuScene.java
+++ b/src/MenuScene.java
@@ -5,9 +5,13 @@ class MenuScene extends SirtetScene {
     public MenuScene() {
         super(false);
         add(new VolumeSliders());
-        add(new SirtetButton(Sirtet.menuImages[ImageID.PlayButton.ordinal()], 260, e -> SirtetWindow.changeScene(SceneID.Gameplay)));
-        add(new SirtetButton(Sirtet.menuImages[ImageID.HighScoreButton.ordinal()], 320, e -> SirtetWindow.changeScene(SceneID.HighScore)));
-        add(new SirtetButton(Sirtet.menuImages[ImageID.QuitButton.ordinal()], 380, e -> {SaveData.writeFile();System.exit(0);}));
+        add(new SirtetButton(Sirtet.menuImages[ImageID.PlayButton.ordinal()], 260, () -> SirtetWindow.changeScene(SceneID.Gameplay)));
+        add(new SirtetButton(Sirtet.menuImages[ImageID.HighScoreButton.ordinal()], 320, () -> SirtetWindow.changeScene(SceneID.HighScore)));
+        add(new SirtetButton(Sirtet.menuImages[ImageID.QuitButton.ordinal()], 380, () -> {
+            Sirtet.audioClips[AudioID.BackgroundMusic.ordinal()].stop();
+            SaveData.writeFile();
+            System.exit(0);
+        }));
         add(new SirtetPanel(false, g -> g.drawImage(Sirtet.menuImages[ImageID.MenuScene.ordinal()], 0, 0, Sirtet.observer)));
     }
 

--- a/src/MenuScene.java
+++ b/src/MenuScene.java
@@ -1,5 +1,3 @@
-import javax.swing.*;
-
 /**
  * This class handles the menu scene and panel. It can launch a new GameplayScene instance, HighScoreScene instance,
  * quit to desktop, or change the bgm/sfx volumes. The JSliders communicate to SirtetAudio to change volume. */

--- a/src/MenuScene.java
+++ b/src/MenuScene.java
@@ -13,11 +13,11 @@ class MenuScene extends SirtetScene {
         add(new SirtetPanel(false, g -> g.drawImage(Sirtet.menuImages[ImageID.MenuScene.ordinal()], 0, 0, Sirtet.observer)));
     }
 
-    void addScene(JFrame parentFrame) {
+    void addScene() {
         setVisible(true);
     }
 
-    void removeScene(JFrame parentFrame) {
+    void removeScene() {
         setVisible(false);
     }
 }

--- a/src/SaveData.java
+++ b/src/SaveData.java
@@ -65,7 +65,7 @@ class SaveData {
 
     /// Inserts score at correct position, moves all names below down by one, starts a new thread to write the file
     public static void insertScore(String currentName) {
-        currentScore -= 25;
+        System.out.println(currentScore);
         if (currentScore < highScores[9].getScore())
             return;
 

--- a/src/SaveData.java
+++ b/src/SaveData.java
@@ -26,8 +26,10 @@ class SaveData {
 
             bgmVolume = Integer.parseInt(fileScanner.nextLine());
             sfxVolume = Integer.parseInt(fileScanner.nextLine());
+
             for (int i = 0; i < 10; i++)
                 highScores[i] = new HighScore(fileScanner.nextLine(), Integer.parseInt(fileScanner.nextLine()));
+
         /// If file does not exist or is corrupted, repair and retry
         } catch (FileNotFoundException | NumberFormatException e) {
             repairSave();
@@ -39,7 +41,6 @@ class SaveData {
     public static void writeFile() {
         try {
             PrintWriter writer = new PrintWriter("Sirtet Data.txt");
-
             writer.println(bgmVolume + "\n" + sfxVolume);
 
             for (HighScore highScore : highScores)
@@ -55,7 +56,6 @@ class SaveData {
     public static void repairSave() {
         try {
             PrintWriter writer = new PrintWriter("Sirtet Data.txt");
-
             writer.print("3\n3\nJex\n45000\nPajitnov\n24700\nKazuma\n19000\nKitsuragi\n15000\nGenichiro\n12000\nRiebeck\n10000\nMundy\n8500\nWinston\n4200\nBlaidd\n3000\nFring\n1250");
             writer.close();
         } catch (Exception e) {

--- a/src/SaveData.java
+++ b/src/SaveData.java
@@ -65,7 +65,6 @@ class SaveData {
 
     /// Inserts score at correct position, moves all names below down by one, starts a new thread to write the file
     public static void insertScore(String currentName) {
-        System.out.println(currentScore);
         if (currentScore < highScores[9].getScore())
             return;
 

--- a/src/SaveData.java
+++ b/src/SaveData.java
@@ -30,7 +30,7 @@ class SaveData {
             for (int i = 0; i < 10; i++)
                 highScores[i] = new HighScore(fileScanner.nextLine(), Integer.parseInt(fileScanner.nextLine()));
 
-        /// If file does not exist or is corrupted, repair and retry
+        // If file does not exist or is corrupted, repair and retry
         } catch (FileNotFoundException | NumberFormatException e) {
             repairSave();
             readFile();

--- a/src/Sirtet.java
+++ b/src/Sirtet.java
@@ -14,15 +14,12 @@ import java.io.File;
  * be loaded, the program force-quits before even displaying the frame, to not waste time. However, if an error occurs,
  * a message pane will be displayed before exiting. */
 public class Sirtet {
-    static final Font SILKSCREEN_60 = new Font("Silkscreen", Font.PLAIN, 60);
-    static final Font SILKSCREEN_40 = new Font("Silkscreen", Font.PLAIN, 40);
-    static final Font SILKSCREEN_30 = new Font("Silkscreen", Font.PLAIN, 30);
 
     static BufferedImage[] gameplaySceneImages = new BufferedImage[8];
     static BufferedImage[] menuImages = new BufferedImage[6];
     static BufferedImage icon;
 
-    /* Creates an ImageObserver interface for BufferedImage to load images with throughout the project.
+    /** Creates an ImageObserver interface for BufferedImage to load images with throughout the project.
      * It returns false. */
     static ImageObserver observer = (a, b, c, d, e, f) -> false;
 
@@ -38,11 +35,10 @@ public class Sirtet {
             new SaveData();
             new SirtetAudio();
             new SirtetWindow();
-        /// If a file does not exist/cannot be found etc.
+        // If a file does not exist/cannot be found etc.
         } catch (Exception e) {
             e.printStackTrace();
             JOptionPane.showMessageDialog(new JFrame(), "Load Error, Check Stack Trace");
-
             System.exit(1);
         }
     }

--- a/src/SirtetButton.java
+++ b/src/SirtetButton.java
@@ -7,11 +7,11 @@ import java.awt.image.BufferedImage;
 /**
  * This class creates a button using provided images and offset. The images will be shown when the button is hovered over,
  * and when not. yPos specifies how far down the panel the button will be, while the x position is always centered. */
-class ReactiveButton extends JButton implements MouseListener {
+class SirtetButton extends JButton implements MouseListener {
     private ImageIcon inactiveImage;
     private ImageIcon activeImage;
 
-    public ReactiveButton(BufferedImage image, int yPos, ActionListener actionListener) {
+    public SirtetButton(BufferedImage image, int yPos, ActionListener actionListener) {
         this.inactiveImage = new ImageIcon(image);
 
         setIcon(inactiveImage);

--- a/src/SirtetButton.java
+++ b/src/SirtetButton.java
@@ -1,4 +1,5 @@
 import javax.swing.*;
+import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
@@ -7,17 +8,19 @@ import java.awt.image.BufferedImage;
 /**
  * This class creates a button using provided images and offset. The images will be shown when the button is hovered over,
  * and when not. yPos specifies how far down the panel the button will be, while the x position is always centered. */
-class SirtetButton extends JButton implements MouseListener {
+class SirtetButton extends JButton implements MouseListener, ActionListener {
     private ImageIcon inactiveImage;
     private ImageIcon activeImage;
+    private ButtonClick buttonClick;
 
-    public SirtetButton(BufferedImage image, int yPos, ActionListener actionListener) {
+    public SirtetButton(BufferedImage image, int yPos, ButtonClick buttonClick) {
         this.inactiveImage = new ImageIcon(image);
+        this.buttonClick = buttonClick;
 
         setIcon(inactiveImage);
 
         addMouseListener(this);
-        addActionListener(actionListener);
+        addActionListener(this);
 
         setContentAreaFilled(false);
         setFocusable(false);
@@ -41,6 +44,15 @@ class SirtetButton extends JButton implements MouseListener {
     /// Resets button icon to 100% scale image when mouse leaves boundaries
     public void mouseExited(MouseEvent ignored) {
         setIcon(inactiveImage);
+    }
+
+    public void actionPerformed(ActionEvent e) {
+        buttonClick.onClick();
+        mouseExited(null);
+    }
+
+    interface ButtonClick {
+        void onClick();
     }
 
     public void mouseClicked(MouseEvent ignored) {}

--- a/src/SirtetGrid.java
+++ b/src/SirtetGrid.java
@@ -72,12 +72,14 @@ class SirtetGrid {
     public void updateGrid(boolean repaint) {
         try {
             populateGrid();
-        /// Recursively calls itself if list is being modified by other process
-        } catch (ConcurrentModificationException ignored) {
+        }
+        // Recursively calls itself if list is being modified by other process
+        catch (ConcurrentModificationException ignored) {
             updateGrid(repaint);
             return;
-        /// If given index not present i.e. deleted recently do nothing
-        } catch (NullPointerException ignored) {}
+        }
+        // If given index not present i.e. deleted recently do nothing
+        catch (NullPointerException ignored) {}
 
         if (repaint)
             parentScene.repaint();

--- a/src/SirtetGrid.java
+++ b/src/SirtetGrid.java
@@ -19,7 +19,7 @@ class SirtetGrid {
 
     private GameplayTimers timer;
 
-    private GameplayScene parentScene;
+    protected GameplayScene parentScene;
 
     private ArrayList<Sonimortet> sonimortetList = new ArrayList<>();
 

--- a/src/SirtetLabel.java
+++ b/src/SirtetLabel.java
@@ -1,0 +1,38 @@
+import javax.swing.*;
+import java.awt.*;
+
+/**
+ * SirtetLabel is an abstract class intended to create specialized JLabels for use in Sirtet. It has subclasses
+ * further specialized in aligning the label in a specific way for use within the program. */
+class SirtetLabel extends JLabel {
+    protected final int xPos;
+    protected final int yPos;
+    protected final int preferredWidth;
+    protected final int preferredHeight;
+
+    public SirtetLabel(String text, FontID fontID, int xPos, int yPos) {
+        setText(text);
+        setFont(SirtetWindow.getFont(fontID));
+        setForeground(Color.black);
+        this.xPos = xPos;
+        this.yPos = yPos;
+        this.preferredWidth = getPreferredSize().width;
+        this.preferredHeight = getPreferredSize().height;
+    }
+}
+
+/// Creates a center-aligned SirtetLabel
+class LabelCenter extends SirtetLabel {
+    public LabelCenter(String text, FontID fontID, int yPos) {
+        super(text, fontID, 0, yPos);
+        setBounds((SirtetWindow.FRAME_SIZE_X - preferredWidth) / 2, yPos, preferredWidth, preferredHeight);
+    }
+}
+
+/// Creates a right-aligned SirtetLabel
+class LabelRight extends SirtetLabel {
+    public LabelRight(String text, FontID fontID, int xPos, int yPos) {
+        super(text, fontID, xPos, yPos);
+        setBounds(xPos - preferredWidth, yPos, preferredWidth, preferredHeight);
+    }
+}

--- a/src/SirtetPanel.java
+++ b/src/SirtetPanel.java
@@ -33,8 +33,22 @@ class SirtetPanel extends JPanel {
      * If not passed, it will be null and skipped. */
     public void paint(Graphics g) {
         super.paint(g);
-
         if (panelPainter != null)
             panelPainter.paint(g);
     }
+}
+
+abstract class SirtetScene extends SirtetPanel {
+    public SirtetScene(boolean opaque, PanelPainter panelPainter) {
+        super(opaque, panelPainter);
+        setVisible(false);
+    }
+
+    public SirtetScene(boolean opaque) {
+        this(opaque, null);
+    }
+
+    abstract void addScene(JFrame parentFrame);
+
+    abstract void removeScene(JFrame parentFrame);
 }

--- a/src/SirtetPanel.java
+++ b/src/SirtetPanel.java
@@ -2,13 +2,6 @@ import javax.swing.*;
 import java.awt.*;
 
 /**
- * Interface for use with SirtetPanel's paint method, the background of a panel. Single method interfaces can be
- * used with lambdas in their implementations. */
-interface PanelPainter {
-    void paint(Graphics g);
-}
-
-/**
  * This is the class that all scene classes extend and use as a starting point to make themselves into their own panels
  * to be added to the frame. It has some initial setup that all panels use, and accepts a PaintPanel interface to paint
  * the background with. This can be null so that nothing is painted. */
@@ -36,19 +29,11 @@ class SirtetPanel extends JPanel {
         if (panelPainter != null)
             panelPainter.paint(g);
     }
-}
 
-abstract class SirtetScene extends SirtetPanel {
-    public SirtetScene(boolean opaque, PanelPainter panelPainter) {
-        super(opaque, panelPainter);
-        setVisible(false);
+    /**
+     * Interface for use with SirtetPanel's paint method, the background of a panel. Single method interfaces can be
+     * used with lambdas in their implementations. */
+    interface PanelPainter {
+        void paint(Graphics g);
     }
-
-    public SirtetScene(boolean opaque) {
-        this(opaque, null);
-    }
-
-    abstract void addScene();
-
-    abstract void removeScene();
 }

--- a/src/SirtetPanel.java
+++ b/src/SirtetPanel.java
@@ -48,7 +48,7 @@ abstract class SirtetScene extends SirtetPanel {
         this(opaque, null);
     }
 
-    abstract void addScene(JFrame parentFrame);
+    abstract void addScene();
 
-    abstract void removeScene(JFrame parentFrame);
+    abstract void removeScene();
 }

--- a/src/SirtetScene.java
+++ b/src/SirtetScene.java
@@ -1,0 +1,14 @@
+/**
+ * A way of setting up scenes in Sirtet with certain always-needed methods to set up/remove the scene from the
+ * main frame. Cannot have a background other than Sirtet Green.
+ */
+abstract class SirtetScene extends SirtetPanel {
+    public SirtetScene(boolean opaque) {
+        super(opaque, null);
+        setVisible(false);
+    }
+
+    abstract void addScene();
+
+    abstract void removeScene();
+}

--- a/src/SirtetWindow.java
+++ b/src/SirtetWindow.java
@@ -35,12 +35,11 @@ class SirtetWindow {
 
     public static void changeScene(SceneID scene) {
         if (currentScene != null)
-            sceneArray[currentScene.ordinal()].removeScene(frame);
+            sceneArray[currentScene.ordinal()].removeScene();
 
         currentScene = scene;
-        sceneArray[currentScene.ordinal()].addScene(frame);
         frame.requestFocus();
-        frame.repaint();
+        sceneArray[currentScene.ordinal()].addScene();
     }
 
     public static Font getFont(FontID fontID) {

--- a/src/SirtetWindow.java
+++ b/src/SirtetWindow.java
@@ -1,3 +1,5 @@
+import sun.nio.ch.sctp.SctpNet;
+
 import javax.swing.*;
 import java.awt.*;
 
@@ -11,122 +13,48 @@ class SirtetWindow {
 
     static JFrame frame = new JFrame("Sirtet");
 
-    static GameplayScene gameplayScene;
-    static MenuScene menuScene;
-    static HighScoreScene highScoreScene;
-    static GameOverScene gameOverScene;
+    static SceneID currentScene = null;
+    static SirtetScene[] sceneArray = new SirtetScene[4];
 
     public SirtetWindow() {
-        changeScene(SceneID.Menu);
+        sceneArray[SceneID.Menu.ordinal()] = new MenuScene();
+        sceneArray[SceneID.Gameplay.ordinal()] = new GameplayScene();
+        sceneArray[SceneID.HighScore.ordinal()] = new HighScoreScene();
+        sceneArray[SceneID.GameOver.ordinal()] = new GameOverScene();
 
+        for (SirtetScene sirtetScene : sceneArray)
+            frame.getContentPane().add(sirtetScene);
+
+        changeScene(SceneID.Menu);
         frame.setIconImage(Sirtet.icon);
         frame.setLayout(null);
         frame.setUndecorated(true);
         frame.setSize(FRAME_SIZE_X, FRAME_SIZE_Y);
-        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         frame.setLocationRelativeTo(null);
         frame.setResizable(false);
         frame.setVisible(true);
     }
 
-    public static void removePreviousScene() {
-        /// Removes menu scene
-        if (menuScene != null) {
-            frame.getContentPane().remove(menuScene);
-            menuScene = null;
-        }
-
-        /// Removes gameplay scene
-        else if (gameplayScene != null) {
-            frame.getContentPane().remove(gameplayScene);
-            frame.removeKeyListener(gameplayScene);
-            gameplayScene.getGrid().stopTimer();
-            gameplayScene = null;
-        }
-
-        /// Removes game over scene
-        else if (gameOverScene != null) {
-            frame.getContentPane().remove(gameOverScene);
-            gameOverScene = null;
-        }
-
-        /// Removes high score scene
-        else if (highScoreScene != null) {
-            frame.getContentPane().remove(highScoreScene);
-            frame.removeKeyListener(highScoreScene);
-            highScoreScene = null;
-        }
-    }
-
     public static void changeScene(SceneID scene) {
+        if (currentScene != null)
+            sceneArray[currentScene.ordinal()].removeScene(frame);
+
+        currentScene = scene;
+        sceneArray[currentScene.ordinal()].addScene(frame);
         frame.requestFocus();
-        removePreviousScene();
-
-        switch (scene) {
-        case Menu:
-            menuScene = new MenuScene();
-            frame.getContentPane().add(menuScene);
-            break;
-        case Gameplay:
-            gameplayScene = new GameplayScene();
-            frame.addKeyListener(gameplayScene);
-            frame.getContentPane().add(gameplayScene);
-            break;
-        case HighScore:
-            highScoreScene = new HighScoreScene();
-            frame.addKeyListener(highScoreScene);
-            frame.getContentPane().add(highScoreScene);
-            break;
-        case GameOver:
-            gameOverScene = new GameOverScene();
-            frame.getContentPane().add(gameOverScene);
-            gameOverScene.focusField();
-            break;
-        default:
-            throw new IllegalStateException("Unexpected value: " + scene);
-        }
-
         frame.repaint();
     }
 
-    /// Generic label setup and return for all other label setups
-    public static JLabel genericLabel(Font font, String text) {
-        JLabel label = new JLabel(text);
-
-        label.setForeground(Color.black);
-        label.setFont(font);
-
-        return label;
-    }
-
-    /// Returns a label justified left
-    public static JLabel labelLeft(String text, Font font, int xPos, int yPos) {
-        JLabel label = genericLabel(font, text);
-
-        label.setBounds(xPos, yPos, label.getPreferredSize().width, label.getPreferredSize().height);
-
-        return label;
-    }
-
-    /// Returns a label justified center
-    public static JLabel labelCenter(String text, Font font, int yPos) {
-        JLabel label = genericLabel(font, text);
-
-        int labelWidth = label.getPreferredSize().width;
-        int labelHeight = label.getPreferredSize().height;
-        label.setBounds((FRAME_SIZE_X - labelWidth) / 2, yPos, labelWidth, labelHeight);
-
-        return label;
-    }
-
-    /// Returns a label justified right
-    public static JLabel labelRight(String text, Font font, int xPos, int yPos) {
-        JLabel label = genericLabel(font, text);
-
-        int labelWidth = label.getPreferredSize().width;
-        int labelHeight = label.getPreferredSize().height;
-        label.setBounds(xPos - labelWidth, yPos, labelWidth, labelHeight);
-
-        return label;
+    public static Font getFont(FontID fontID) {
+        switch (fontID) {
+        case Silk30:
+            return new Font("Silkscreen", Font.PLAIN, 30);
+        case Silk40:
+            return new Font("Silkscreen", Font.PLAIN, 40);
+        case Silk60:
+            return new Font("Silkscreen", Font.PLAIN, 60);
+        default:
+            throw new RuntimeException("Unexpected Value: " + fontID);
+        }
     }
 }

--- a/src/SirtetWindow.java
+++ b/src/SirtetWindow.java
@@ -19,7 +19,6 @@ class SirtetWindow {
         sceneArray[SceneID.Gameplay.ordinal()] = new GameplayScene();
         sceneArray[SceneID.HighScore.ordinal()] = new HighScoreScene();
         sceneArray[SceneID.GameOver.ordinal()] = new GameOverScene();
-
         for (SirtetScene sirtetScene : sceneArray)
             frame.getContentPane().add(sirtetScene);
 

--- a/src/SirtetWindow.java
+++ b/src/SirtetWindow.java
@@ -1,5 +1,3 @@
-import sun.nio.ch.sctp.SctpNet;
-
 import javax.swing.*;
 import java.awt.*;
 

--- a/src/Sonimortet.java
+++ b/src/Sonimortet.java
@@ -62,6 +62,7 @@ class Sonimortet {
 
     /// Goes to game over etc.
     public void gameOver() {
+        SaveData.currentScore -= 25;
         parentGrid.stopTimer();
         SirtetAudio.playAudio(AudioID.GameOver);
         SirtetWindow.changeScene(SceneID.GameOver);

--- a/src/Sonimortet.java
+++ b/src/Sonimortet.java
@@ -8,21 +8,18 @@
 class Sonimortet {
     final int xInd = 0; // Index of x in position array
     final int yInd = 1; // Index of y in position array
-
+    final int startingPositionsLength = 4;
     private int rotation;
 
     private BlockID type;
-
     private SirtetGrid parentGrid;
-
     private SonimortetPositions[] positions;
 
     public Sonimortet(BlockID type, SirtetGrid parentGrid) {
         rotation = 0;
         this.type = type;
         this.parentGrid = parentGrid;
-        positions = new SonimortetPositions[4];
-
+        positions = new SonimortetPositions[startingPositionsLength];
         setStartingPositions();
     }
 
@@ -57,7 +54,7 @@ class Sonimortet {
             return;
         }
 
-        for (int i = 0; i < 4; i++)
+        for (int i = 0; i < startingPositionsLength; i++)
             positions[i] = new SonimortetPositions(startingPositions[xInd][i], startingPositions[yInd][i]);
 
         parentGrid.restartTimer();
@@ -72,40 +69,35 @@ class Sonimortet {
 
     /// Checks to see if sonimortet can be placed at given position array
     public boolean canPlace(int[][] positions) {
-        for (int i = 0; i < 4; i++)
+        for (int i = 0; i < startingPositionsLength; i++)
             if (parentGrid.getGrid(positions[xInd][i], positions[yInd][i]))
                 return false;
-
         return true;
     }
 
     /// Checks to see if the whole sonimortet can move to an offset
     public boolean allCanMove(int xOffset, int yOffset) {
-        for (int i = 0; i < positions.length; i++)
+        for (int i = 0; i < startingPositionsLength; i++)
             if (!singleCanMove(i, xOffset, yOffset, false))
                 return false;
-
         return true;
     }
 
     /// Checks to see if a single piece of this sonimortet can move to an offset
     public boolean singleCanMove(int index, int xOffset, int yOffset, boolean invert) {
+        parentGrid.updateGrid(false);
         if (invert) {
             xOffset *= -1;
             yOffset *= -1;
         }
-
-        parentGrid.updateGrid(false);
 
         int x = positions[index].getX();
         int y = positions[index].getY();
 
         if (isEdge(x, xOffset, y, yOffset))
             return false;
-
         if (parentGrid.getGrid(x + xOffset, y + yOffset))
             return isSameSonimortet(x, xOffset, y, yOffset);
-
         return true;
     }
 
@@ -113,10 +105,8 @@ class Sonimortet {
     public boolean isEdge(int x, int xOffset, int y, int yOffset) {
         if (y + yOffset > SirtetGrid.gridSizeY - 1) // Going off bottom
             return true;
-
         if (x + xOffset < 0) // Going off left
             return true;
-
         return (x + xOffset > SirtetGrid.gridSizeX - 1); // Going off right
     }
 
@@ -125,7 +115,6 @@ class Sonimortet {
         for (SonimortetPositions position : positions)
             if (position.getX() == thisX + xOffset && position.getY() == thisY + yOffset)
                 return true;
-
         return false;
     }
 
@@ -153,7 +142,6 @@ class Sonimortet {
     /// Drops to bottommost possible position
     public void hardDrop() {
         shiftAll(0, getHeight());
-
         parentGrid.addSonimortet();
         GameplayTimers.decrementTimer();
     }
@@ -359,7 +347,7 @@ class Sonimortet {
         if (!canRotate(shiftX, shiftY, invert))
             return;
 
-        for (int i = 0; i < 4; i++)
+        for (int i = 0; i < startingPositionsLength; i++)
             positions[i].shiftSingle(shiftX[i], shiftY[i], invert);
 
         if (invert)
@@ -369,7 +357,7 @@ class Sonimortet {
     }
 
     public boolean canRotate(int[] shiftX, int[] shiftY, boolean invert) {
-        for (int i = 0; i < positions.length; i++) {
+        for (int i = 0; i < startingPositionsLength; i++) {
             if (!singleCanMove(i, shiftX[i], shiftY[i], invert)) {
                 if (allCanMove(-1, 0)) {
                     shiftAll(-1, 0);

--- a/src/VolumeSliders.java
+++ b/src/VolumeSliders.java
@@ -1,6 +1,7 @@
 import javax.swing.*;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
+import java.util.ArrayList;
 
 /**
  * This class holds a JPanel with JSliders within. Because these same JSliders and their functionality
@@ -12,6 +13,7 @@ class VolumeSliders extends SirtetPanel implements ChangeListener {
 
     public VolumeSliders() {
         super(false);
+        VolumeSlidersMaster.addSliderObject(this);
 
         bgmSlider.setBounds(191, 720, 100, 50);
         bgmSlider.setValue(SaveData.bgmVolume);
@@ -27,10 +29,8 @@ class VolumeSliders extends SirtetPanel implements ChangeListener {
     /// Sets up and returns a JSlider object
     public JSlider sliderSetup() {
         JSlider slider = new JSlider(0, 9);
-
         slider.setOpaque(false);
         slider.addChangeListener(this);
-
         return slider;
     }
 
@@ -44,6 +44,29 @@ class VolumeSliders extends SirtetPanel implements ChangeListener {
         else if (e.getSource() == sfxSlider)
             SaveData.sfxVolume = sfxSlider.getValue();
 
+        VolumeSlidersMaster.updateAll();
+
         SirtetWindow.frame.requestFocus();
+    }
+
+    public void updateSliders() {
+        bgmSlider.setValue(SaveData.bgmVolume);
+        sfxSlider.setValue(SaveData.sfxVolume);
+    }
+}
+
+/**
+ * This class exists simply to update the values of all volume sliders objects when a value is changed in only one
+ * of them. Without this, the values would be inconsistent between different VolumeSlider objects. */
+class VolumeSlidersMaster {
+    private static ArrayList<VolumeSliders> slidersArray = new ArrayList<>();
+
+    public static void addSliderObject(VolumeSliders slidersObject) {
+        slidersArray.add(slidersObject);
+    }
+
+    public static void updateAll() {
+        for (VolumeSliders sliders : slidersArray)
+            sliders.updateSliders();
     }
 }

--- a/src/VolumeSliders.java
+++ b/src/VolumeSliders.java
@@ -8,12 +8,14 @@ import java.util.ArrayList;
  * are used by multiple other classes, it made sense to make them their own class to have
  * it editable all in the same place. */
 class VolumeSliders extends SirtetPanel implements ChangeListener {
+    private static ArrayList<VolumeSliders> slidersArrayList = new ArrayList<>();
+
     private JSlider bgmSlider = sliderSetup();
     private JSlider sfxSlider = sliderSetup();
 
     public VolumeSliders() {
         super(false);
-        VolumeSlidersMaster.addSliderObject(this);
+        slidersArrayList.add(this);
 
         bgmSlider.setBounds(191, 720, 100, 50);
         bgmSlider.setValue(SaveData.bgmVolume);
@@ -44,29 +46,14 @@ class VolumeSliders extends SirtetPanel implements ChangeListener {
         else if (e.getSource() == sfxSlider)
             SaveData.sfxVolume = sfxSlider.getValue();
 
-        VolumeSlidersMaster.updateAll();
-
+        updateAllSliders();
         SirtetWindow.frame.requestFocus();
     }
 
-    public void updateSliders() {
-        bgmSlider.setValue(SaveData.bgmVolume);
-        sfxSlider.setValue(SaveData.sfxVolume);
-    }
-}
-
-/**
- * This class exists simply to update the values of all volume sliders objects when a value is changed in only one
- * of them. Without this, the values would be inconsistent between different VolumeSlider objects. */
-class VolumeSlidersMaster {
-    private static ArrayList<VolumeSliders> slidersArray = new ArrayList<>();
-
-    public static void addSliderObject(VolumeSliders slidersObject) {
-        slidersArray.add(slidersObject);
-    }
-
-    public static void updateAll() {
-        for (VolumeSliders sliders : slidersArray)
-            sliders.updateSliders();
+    public static void updateAllSliders() {
+        for (VolumeSliders sliders : slidersArrayList) {
+            sliders.bgmSlider.setValue(SaveData.bgmVolume);
+            sliders.sfxSlider.setValue(SaveData.sfxVolume);
+        }
     }
 }

--- a/src/VolumeSliders.java
+++ b/src/VolumeSliders.java
@@ -50,7 +50,7 @@ class VolumeSliders extends SirtetPanel implements ChangeListener {
         SirtetWindow.frame.requestFocus();
     }
 
-    public static void updateAllSliders() {
+    private static void updateAllSliders() {
         for (VolumeSliders sliders : masterSlidersList) {
             sliders.bgmSlider.setValue(SaveData.bgmVolume);
             sliders.sfxSlider.setValue(SaveData.sfxVolume);

--- a/src/VolumeSliders.java
+++ b/src/VolumeSliders.java
@@ -8,14 +8,14 @@ import java.util.ArrayList;
  * are used by multiple other classes, it made sense to make them their own class to have
  * it editable all in the same place. */
 class VolumeSliders extends SirtetPanel implements ChangeListener {
-    private static ArrayList<VolumeSliders> slidersArrayList = new ArrayList<>();
+    private static ArrayList<VolumeSliders> masterSlidersList = new ArrayList<>();
 
     private JSlider bgmSlider = sliderSetup();
     private JSlider sfxSlider = sliderSetup();
 
     public VolumeSliders() {
         super(false);
-        slidersArrayList.add(this);
+        masterSlidersList.add(this);
 
         bgmSlider.setBounds(191, 720, 100, 50);
         bgmSlider.setValue(SaveData.bgmVolume);
@@ -51,7 +51,7 @@ class VolumeSliders extends SirtetPanel implements ChangeListener {
     }
 
     public static void updateAllSliders() {
-        for (VolumeSliders sliders : slidersArrayList) {
+        for (VolumeSliders sliders : masterSlidersList) {
             sliders.bgmSlider.setValue(SaveData.bgmVolume);
             sliders.sfxSlider.setValue(SaveData.sfxVolume);
         }


### PR DESCRIPTION
- Added new enum, FontID for getting fonts from SirtetWindow, final Font objects of Sirtet removed and replaced
with the GetFont method of SirtetWindow, which takes a FontID and gives a Font object
- All scene classes now extend new abstract class SirtetScene instead of SirtetPanel as they used to. This allows
for added ease of use for scene adding/removing in SirtetWindow as all extenders of SirtetScene now must implement
abstract methods addScene and removeScene, which allows each scene to be added to and removed from the main window
much easier
- GameplayScene no longer constructed and deconstructed to start/stop games, now is a constant object that is reset
across playing the game
- Miscellaneous documentation updates
- ReactiveButton changed to SirtetButton, now takes a special functional interface called ButtonClick. This can
ensure that the correct image is reset to after clicking the button, no longer lingering on the smaller image after
switching scenes
- Created SirtetLabel class alongside LabelCenter and LabelRight classes for making new JLabels with some presets
for ease of use
- Functional interface PanelPainter moved inside SirtetPanel for organization purposes
- How SirtetWindow handles objects of scene classes revamped completely. With the help of abstract class SirtetScene,
the process of adding/removing scenes to the frame was streamlined, and methods were made more concise.
- Fixed the use of some magic numbers
- VolumeSliders now has a static ArrayList of all VolumeSliders instances in the program to facilitate updates going
out to all simultaneously without extraneous method calls